### PR TITLE
Fix payload type in `MessageEvent`

### DIFF
--- a/vkbottle_types/events/bot_events.py
+++ b/vkbottle_types/events/bot_events.py
@@ -51,6 +51,10 @@ class MessageTypingState(BaseGroupEvent):
 class MessageEvent(BaseGroupEvent):
     object: group_event_objects.MessageEventObject
 
+    def get_payload_json(self, *args, **kwargs) -> Optional[dict]:
+        # Нужно для рулов связанных с пейлоадом
+        return self.object.get_payload_json(*args, **kwargs)
+
 
 class PhotoNew(BaseGroupEvent):
     object: group_event_objects.PhotoNewObject

--- a/vkbottle_types/events/objects/group_event_objects.py
+++ b/vkbottle_types/events/objects/group_event_objects.py
@@ -59,7 +59,7 @@ class MessageEventObject(BaseEventObject):
     user_id: Optional[int] = None
     peer_id: Optional[int] = None
     event_id: Optional[str] = None
-    payload: Optional[str] = None
+    payload: Union[str, dict, None] = None
     conversation_message_id: Optional[int] = None
 
     @property
@@ -71,7 +71,9 @@ class MessageEventObject(BaseEventObject):
         throw_error: bool = False,
         unpack_failure: Callable[[str], dict] = lambda payload: payload,
         json: Any = __import__("json"),
-    ) -> Union[dict, None]:
+    ) -> Optional[dict]:
+        if isinstance(self.payload, dict):
+            return self.payload
         try:
             return json.loads(self.payload)
         except (json.decoder.JSONDecodeError, TypeError) as e:


### PR DESCRIPTION
В поле `payload` может прийти словарь вместо строки.