### PR TITLE
fix: bump python version (similar to vkbottle)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ packages = [
 ]
 
 [tool.poetry.dependencies]
-python = "^3.7"
+python = "^3.7.2"
 pydantic = "^1.6.1"
 vkbottle = "^4.1"
 


### PR DESCRIPTION
### Описание

В проекте не срабатывает `poetry install`, т.к. ругается на несоответствие версии python в `vkbottle`.
Пофиксить можно либо срезанием [патч-версии в vkbottle](https://github.com/vkbottle/vkbottle/blob/41c6138d3b0cf0e36a552dcdfc88719dce0441dc/pyproject.toml#L39), либо наращиваем её здесь.