### PR TITLE
Update objects.py

### DIFF
--- a/vkbottle_types/codegen/objects.py
+++ b/vkbottle_types/codegen/objects.py
@@ -12385,6 +12385,9 @@ class MessagesKeyboardButtonPropertyAction(BaseModel):
     """
     Model: `MessagesKeyboardButtonPropertyAction`
     """
+    label: str = Field()
+    type: str = Field()
+    payload: str = Field()
 
 
 class MessagesLastActivity(BaseModel):


### PR DESCRIPTION
Без этого исправления невозможно получить объект клавиатуры через messages.getHistory
имеет вот такой вид [MessagesKeyboardButton(action=MessagesKeyboardButtonPropertyAction(), color=<MessagesKeyboardButtonColor.POSITIVE: 'positive'>)]