### PR TITLE
perf: defer pydantic schema build to cut import-time RSS

### DIFF
--- a/vkbottle_types/base_model.py
+++ b/vkbottle_types/base_model.py
@@ -42,7 +42,7 @@ else:
     ORIG_MODULE_NAMESPACE_ATTR = "__orig_module_namespace__"
 
     class BaseModel(pydantic.BaseModel):
-        model_config = pydantic.ConfigDict(frozen=True)
+        model_config = pydantic.ConfigDict(frozen=True, defer_build=True)
 
         @classmethod
         def object_build(cls, localns, /):

--- a/vkbottle_types/objects.py
+++ b/vkbottle_types/objects.py
@@ -344,13 +344,11 @@ if not TYPE_CHECKING:
         if not (isinstance(item, type) and item is not BaseModel and issubclass(item, BaseModel)):
             continue
 
-        item.model_rebuild(force=True, _types_namespace=types_namespace)
         item.set_original_module_namespace(types_namespace)
 
         for parent in item.__bases__:
             if parent.__name__ == item.__name__ and issubclass(parent, BaseModel):
                 parent.__pydantic_fields__.update(item.__pydantic_fields__)
-                parent.model_rebuild(force=True, _types_namespace=types_namespace)
                 parent.set_original_module_namespace(types_namespace)
                 item.__pydantic_fields__.update(
                     {name: field for name, field in parent.__pydantic_fields__.items() if name not in item.__pydantic_fields__},

--- a/vkbottle_types/responses/__init__.py
+++ b/vkbottle_types/responses/__init__.py
@@ -56,13 +56,11 @@ if not typing.TYPE_CHECKING:
         if not (isinstance(item, type) and item is not objects.BaseModel and issubclass(item, objects.BaseModel)):
             continue
 
-        item.model_rebuild(force=True, _types_namespace=types_namespace)
         item.set_original_module_namespace(localns)
 
         for parent in item.__bases__:
             if parent.__name__ == item.__name__ and issubclass(parent, objects.BaseModel):
                 parent.__pydantic_fields__.update(item.__pydantic_fields__)
-                parent.model_rebuild(force=True, _types_namespace=types_namespace)
                 parent.set_original_module_namespace(localns)
                 item.__pydantic_fields__.update(
                     {name: field for name, field in parent.__pydantic_fields__.items() if name not in item.__pydantic_fields__},


### PR DESCRIPTION
```
step                              before     after
---------------------------------------------------
import vkbottle_types             571 MB    61 MB
from vkbottle.bot import Bot      597 MB    97 MB
Bot(token=...)                    597 MB    97 MB
```

Refs: vkbottle/vkbottle#1198