### PR TITLE
fix: inner_type now can be None in WallWallpost and WallWallpostFull

### DIFF
--- a/vkbottle_types/objects.py
+++ b/vkbottle_types/objects.py
@@ -337,7 +337,7 @@ class ClientInfoForBots(BaseModel):
     """client has support inline keyboard."""
 
     carousel: bool | None = Field(
-        default=None, 123
+        default=None,
     )
     """client has support carousel."""
 

--- a/vkbottle_types/objects.py
+++ b/vkbottle_types/objects.py
@@ -199,6 +199,14 @@ class StoriesStory(StoriesStory):
     photo: PhotosPhoto | None = None
 
 
+class WallWallpost(WallWallpost):
+    inner_type: WallWallpostInnerType | None = None
+    
+
+class WallWallpostFull(WallWallpostFull):
+    inner_type: WallWallpostInnerType | None = None
+
+
 class WallCommentAttachment(WallCommentAttachment):
     photo: PhotosPhoto | None = None
 
@@ -329,7 +337,7 @@ class ClientInfoForBots(BaseModel):
     """client has support inline keyboard."""
 
     carousel: bool | None = Field(
-        default=None,
+        default=None, 123
     )
     """client has support carousel."""
 


### PR DESCRIPTION
https://github.com/vkbottle/vkbottle/issues/1210

## Tested on this code 
```python
log_format = (
    "<level>{level: <8}</level> <bold><level>|</level></bold> "
    "{time:YYYY-MM-DD HH:mm:ss} <bold><level>|</level></bold> "
    "{name}:{function}:{line}<bold><level> > </level></bold><level>{message}</level>"
)
logger.remove()
logger.add(
    sys.stderr,
    format=log_format,
    enqueue=True,
    colorize=True,
    level="INFO",
)

async def main():
    try:
        wall_posts = await _api.wall.get(domain='marinakravets_official', count=100)

        for post in wall_posts.items:
            logger.info(post.inner_type)
    except ValidationError as e:
        logger.error("Ошибка валидации Pydantic:")
        logger.error(f"Количество ошибок: {len(e.errors())}")
        for error in e.errors():
            logger.error(f"  - Поле: {'.'.join(str(loc) for loc in error['loc'])}")
            logger.error(f"    Тип: {error['type']}")
            logger.error(f"    Сообщение: {error['msg']}")
            logger.error(f"    Входное значение: {error.get('input', 'N/A')}")
            logger.error(f"    Контекст: {error.get('ctx', {})}")
        #logger.error(f"Полный текст ошибки:\n{e}")
        
if __name__ == "__main__":
    asyncio.run(main())
 ```
 
 ## Output before fix
 ```bash
 ERROR    | 2026-07-29 15:38:42 | __main__:main:85 > Ошибка валидации Pydantic:
ERROR    | 2026-07-29 15:38:42 | __main__:main:86 > Количество ошибок: 4
ERROR    | 2026-07-29 15:38:42 | __main__:main:88 >   - Поле: response.items.2.inner_type
ERROR    | 2026-07-29 15:38:42 | __main__:main:89 >     Тип: missing
ERROR    | 2026-07-29 15:38:42 | __main__:main:90 >     Сообщение: Field required
ERROR    | 2026-07-29 15:38:42 | __main__:main:91 >     Входное значение: ...
 ```
 ## Output after fix
 ```bash
INFO     | 2026-07-29 15:39:19 | __main__:main:82 > wall_wallpost
INFO     | 2026-07-29 15:39:19 | __main__:main:82 > wall_wallpost
INFO     | 2026-07-29 15:39:19 | __main__:main:82 > None
INFO     | 2026-07-29 15:39:19 | __main__:main:82 > wall_wallpost
INFO     | 2026-07-29 15:39:19 | __main__:main:82 > wall_wallpost
INFO     | 2026-07-29 15:39:19 | __main__:main:82 > wall_wallpost
INFO     | 2026-07-29 15:39:19 | __main__:main:82 > wall_wallpost
INFO     | 2026-07-29 15:39:19 | __main__:main:82 > wall_wallpost
INFO     | 2026-07-29 15:39:19 | __main__:main:82 > wall_wallpost
INFO     | 2026-07-29 15:39:19 | __main__:main:82 > wall_wallpost
INFO     | 2026-07-29 15:39:19 | __main__:main:82 > None
...
 ```